### PR TITLE
Implement Python quantitative trading system

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -1,0 +1,60 @@
+"""回测模块，封装Backtrader回测流程。"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import backtrader as bt
+import pandas as pd
+
+from data_fetcher import fetch_data
+from strategy import MAStrategy
+
+logger = logging.getLogger(__name__)
+
+
+def _build_data_feed(data_df: pd.DataFrame) -> bt.feeds.PandasData:
+    """将DataFrame转换为Backtrader数据源。"""
+    data_feed = bt.feeds.PandasData(dataname=data_df)
+    return data_feed
+
+
+def run_backtest(
+    symbol: str,
+    start_date: str,
+    end_date: str,
+    cash: float = 100_000.0,
+    commission: float = 0.001,
+    short_window: int = 20,
+    long_window: int = 50,
+) -> Optional[float]:
+    """运行双均线策略回测。
+
+    返回最终资产价值，若失败返回None。
+    """
+    data_df = fetch_data(symbol, start_date, end_date)
+    if data_df is None or data_df.empty:
+        logger.error("run_backtest: 无法获取历史数据，终止回测")
+        return None
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(_build_data_feed(data_df))
+    cerebro.addstrategy(MAStrategy, short_window=short_window, long_window=long_window)
+    cerebro.broker.setcash(cash)
+    cerebro.broker.setcommission(commission=commission)
+
+    logger.info(
+        "开始回测 %s，资金 %.2f，短均线 %d，长均线 %d",
+        symbol,
+        cash,
+        short_window,
+        long_window,
+    )
+    cerebro.run()
+    final_value = cerebro.broker.getvalue()
+    logger.info("回测完成，最终资金 %.2f", final_value)
+    print(f"Backtest Results - Final Portfolio Value: {final_value:.2f}")
+    return final_value
+
+
+__all__ = ["run_backtest"]

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,48 @@
+"""行情数据获取模块。
+
+该模块通过yfinance库从Yahoo Finance获取历史行情数据。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_data(symbol: str, start_date: str, end_date: str, interval: str = "1d") -> Optional[pd.DataFrame]:
+    """从Yahoo Finance获取历史行情数据。
+
+    参数:
+        symbol: 股票或其他金融标的代码，例如"AAPL"。
+        start_date: 数据开始日期，格式"YYYY-MM-DD"。
+        end_date: 数据结束日期，格式"YYYY-MM-DD"。
+        interval: 数据频率，默认为"1d"日线。
+
+    返回:
+        如果成功，返回按日期索引排序的pandas.DataFrame；若失败则返回None。
+    """
+    try:
+        logger.debug(
+            "fetch_data: downloading data", extra={"symbol": symbol, "start": start_date, "end": end_date}
+        )
+        df = yf.download(symbol, start=start_date, end=end_date, interval=interval, progress=False)
+    except Exception as exc:  # pragma: no cover - 网络错误难以预测
+        logger.error("获取行情数据失败: %s", exc)
+        return None
+
+    if df.empty:
+        logger.warning("fetch_data: 未获取到 %s 在%s至%s的数据", symbol, start_date, end_date)
+        return df
+
+    # 将索引转为DatetimeIndex并排序，去除缺失值，确保数据质量。
+    df.index = pd.to_datetime(df.index)
+    df.sort_index(inplace=True)
+    df.dropna(how="any", inplace=True)
+    return df
+
+
+__all__ = ["fetch_data"]

--- a/database.py
+++ b/database.py
@@ -1,0 +1,101 @@
+"""数据库模块，使用SQLite存储行情与交易记录。"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+DB_FILE = Path("trading.db")
+
+_conn = sqlite3.connect(DB_FILE, check_same_thread=False)
+_cursor = _conn.cursor()
+
+
+def init_db() -> None:
+    """初始化数据库表结构。"""
+    try:
+        _cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS prices (
+                symbol TEXT,
+                date TEXT,
+                open REAL,
+                high REAL,
+                low REAL,
+                close REAL,
+                volume REAL,
+                PRIMARY KEY(symbol, date)
+            )
+            """
+        )
+        _cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                datetime TEXT,
+                symbol TEXT,
+                action TEXT,
+                price REAL,
+                quantity INTEGER
+            )
+            """
+        )
+        _conn.commit()
+        logger.info("数据库初始化完成，文件位于 %s", DB_FILE.resolve())
+    except Exception as exc:
+        logger.error("数据库初始化失败: %s", exc)
+
+
+def save_price_data(df: pd.DataFrame, symbol: str) -> None:
+    """保存行情数据至prices表。"""
+    try:
+        records: List[Tuple[str, str, float, float, float, float, float]] = []
+        for date, row in df.iterrows():
+            date_str = date.strftime("%Y-%m-%d")
+            records.append(
+                (
+                    symbol,
+                    date_str,
+                    float(row.get("Open", 0.0)),
+                    float(row.get("High", 0.0)),
+                    float(row.get("Low", 0.0)),
+                    float(row.get("Close", 0.0)),
+                    float(row.get("Volume", 0.0)),
+                )
+            )
+        if records:
+            _cursor.executemany(
+                """
+                INSERT OR REPLACE INTO prices(symbol, date, open, high, low, close, volume)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                records,
+            )
+            _conn.commit()
+    except Exception as exc:
+        logger.error("保存行情数据出错: %s", exc)
+
+
+def record_trade(symbol: str, action: str, price: float, quantity: int) -> None:
+    """记录交易行为。"""
+    try:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        _cursor.execute(
+            """
+            INSERT INTO trades(datetime, symbol, action, price, quantity)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (now, symbol, action, float(price), int(quantity)),
+        )
+        _conn.commit()
+    except Exception as exc:
+        logger.error("记录交易失败: %s", exc)
+
+
+__all__ = ["init_db", "save_price_data", "record_trade"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# 一键部署脚本：用于在Ubuntu服务器上安装依赖并启动量化交易系统。
+set -euo pipefail
+
+PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+VENV_DIR="$PROJECT_DIR/.venv"
+
+function log_info() {
+  echo "[INFO] $1"
+}
+
+log_info "更新系统包索引..."
+sudo apt-get update
+
+log_info "安装Python3及基础依赖..."
+sudo apt-get install -y python3 python3-venv python3-pip
+
+if [ ! -d "$VENV_DIR" ]; then
+  log_info "创建Python虚拟环境..."
+  python3 -m venv "$VENV_DIR"
+fi
+
+log_info "激活虚拟环境并安装项目依赖..."
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip
+if [ -f "$PROJECT_DIR/requirements.txt" ]; then
+  pip install -r "$PROJECT_DIR/requirements.txt"
+else
+  pip install backtrader yfinance apscheduler pandas
+fi
+
+log_info "初始化数据库..."
+python3 -c "from database import init_db; init_db()"
+
+log_info "部署完成，可使用如下命令运行系统："
+cat <<USAGE
+----------------------------------------
+回测模式:   $VENV_DIR/bin/python main.py backtest
+实盘调度:   $VENV_DIR/bin/python main.py
+----------------------------------------
+USAGE

--- a/main.py
+++ b/main.py
@@ -1,0 +1,106 @@
+"""系统主入口，提供回测与定时交易功能。"""
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from backtester import run_backtest
+from data_fetcher import fetch_data
+from database import init_db, save_price_data
+from trader import Trader
+
+# 全局日志配置
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[
+        logging.FileHandler("trading.log", encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+# 默认配置，可根据需要调整
+SYMBOL = "AAPL"
+LOOKBACK_DAYS = 60
+SHORT_WINDOW = 20
+LONG_WINDOW = 50
+
+
+def _calculate_signal(data: pd.DataFrame) -> int:
+    """根据双均线产生交易信号。
+
+    返回 1 表示买入，-1 表示卖出，0 表示无动作。
+    """
+    close_prices = data["Close"]
+    if len(close_prices) < LONG_WINDOW:
+        logger.warning("数据长度不足，无法计算均线")
+        return 0
+
+    ma_short = close_prices.rolling(window=SHORT_WINDOW).mean()
+    ma_long = close_prices.rolling(window=LONG_WINDOW).mean()
+
+    prev_short = ma_short.iloc[-2]
+    prev_long = ma_long.iloc[-2]
+    latest_short = ma_short.iloc[-1]
+    latest_long = ma_long.iloc[-1]
+
+    if any(value != value for value in (prev_short, prev_long, latest_short, latest_long)):
+        # 包含缺失值时不产生信号
+        return 0
+
+    if prev_short <= prev_long and latest_short > latest_long:
+        return 1
+    if prev_short >= prev_long and latest_short < latest_long:
+        return -1
+    return 0
+
+
+def run_daily_job(trader: Trader) -> None:
+    """每日调度任务：获取数据、计算信号并执行交易。"""
+    try:
+        end_date = datetime.now()
+        start_date = end_date - timedelta(days=LOOKBACK_DAYS)
+        data = fetch_data(SYMBOL, start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d"))
+        if data is None or data.empty:
+            logger.error("run_daily_job: 未能获取到行情数据")
+            return
+        save_price_data(data, SYMBOL)
+
+        signal = _calculate_signal(data)
+        price = float(data["Close"].iloc[-1])
+        current_pos = trader.current_position()
+
+        if signal == 1 and current_pos == 0:
+            trader.buy(SYMBOL, price, quantity=100)
+        elif signal == -1 and current_pos > 0:
+            trader.sell(SYMBOL, price, quantity=current_pos)
+        else:
+            logger.info("当日无交易执行，信号=%s，持仓=%s", signal, current_pos)
+    except Exception as exc:  # pragma: no cover - 调度任务中捕获所有异常
+        logger.error("执行日常任务失败: %s", exc, exc_info=True)
+
+
+def _run_scheduler() -> None:
+    """启动APScheduler调度。"""
+    trader = Trader()
+    scheduler = BlockingScheduler()
+    scheduler.add_job(run_daily_job, "cron", day_of_week="mon-fri", hour=9, minute=30, args=[trader])
+    logger.info("启动交易调度器，目标标的 %s", SYMBOL)
+    scheduler.start()
+
+
+if __name__ == "__main__":
+    init_db()
+    if len(sys.argv) > 1 and sys.argv[1].lower() == "backtest":
+        start_date = (datetime.now() - timedelta(days=365)).strftime("%Y-%m-%d")
+        end_date = datetime.now().strftime("%Y-%m-%d")
+        run_backtest(SYMBOL, start_date, end_date, short_window=SHORT_WINDOW, long_window=LONG_WINDOW)
+        sys.exit(0)
+
+    _run_scheduler()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+backtrader
+pandas
+yfinance
+apscheduler

--- a/strategy.py
+++ b/strategy.py
@@ -1,0 +1,41 @@
+"""策略模块，定义双均线策略类。"""
+from __future__ import annotations
+
+import backtrader as bt
+
+
+class MAStrategy(bt.Strategy):
+    """双均线交叉策略。
+
+    当短期均线上穿长期均线时买入，当短期均线下穿长期均线时卖出。
+    """
+
+    params = ("short_window", 20), ("long_window", 50)
+
+    def __init__(self) -> None:
+        # 初始化短期与长期移动平均线指标
+        self.ma_short = bt.indicators.SimpleMovingAverage(self.data.close, period=self.p.short_window)
+        self.ma_long = bt.indicators.SimpleMovingAverage(self.data.close, period=self.p.long_window)
+
+    def next(self) -> None:
+        """每个新bar到来时执行交易逻辑。"""
+        if len(self.ma_short) < 2 or len(self.ma_long) < 2:
+            # 尚未形成足够长的历史均线
+            return
+
+        prev_short = self.ma_short[-1]
+        prev_long = self.ma_long[-1]
+        latest_short = self.ma_short[0]
+        latest_long = self.ma_long[0]
+
+        # 金叉触发买入
+        if prev_short <= prev_long and latest_short > latest_long:
+            if not self.position:
+                self.buy()
+        # 死叉触发卖出
+        elif prev_short >= prev_long and latest_short < latest_long:
+            if self.position:
+                self.sell()
+
+
+__all__ = ["MAStrategy"]

--- a/trader.py
+++ b/trader.py
@@ -1,0 +1,43 @@
+"""交易执行模块，提供模拟交易账户。"""
+from __future__ import annotations
+
+import logging
+
+from database import record_trade
+
+logger = logging.getLogger(__name__)
+
+
+class Trader:
+    """简单的单标的模拟交易账户。"""
+
+    def __init__(self) -> None:
+        self.position = 0
+
+    def buy(self, symbol: str, price: float, quantity: int = 100) -> bool:
+        """模拟买入指定数量。"""
+        if self.position > 0:
+            logger.warning("buy: 已有持仓，忽略重复买入")
+            return False
+        self.position += quantity
+        logger.info("买入 %s 数量 %d，价格 %.2f", symbol, quantity, price)
+        record_trade(symbol, "BUY", price, quantity)
+        return True
+
+    def sell(self, symbol: str, price: float, quantity: int = 100) -> bool:
+        """模拟卖出指定数量，默认全部卖出。"""
+        if self.position <= 0:
+            logger.warning("sell: 当前为空仓，无法卖出")
+            return False
+        sell_qty = min(quantity, self.position)
+        self.position -= sell_qty
+        logger.info("卖出 %s 数量 %d，价格 %.2f", symbol, sell_qty, price)
+        record_trade(symbol, "SELL", price, sell_qty)
+        return True
+
+    def current_position(self) -> int:
+        """返回当前持仓数量。"""
+        return self.position
+
+
+__all__ = ["Trader"]


### PR DESCRIPTION
## Summary
- add Yahoo Finance data fetcher with logging and preprocessing
- implement Backtrader-based moving average strategy, backtesting, and simulated trader
- introduce SQLite persistence, APScheduler-driven main entrypoint, and deployment script with dependencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68cb9ba81e5c8329b46c3c46680fa804